### PR TITLE
Use get_grid_node_count fix from bmi-example-python

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog for pymt_heatpy
 ----------------
 
 - Use *set_value* fix from bmi-example-python (#1)
+- Use *get_grid_node_count* fix from bmi-example-python (#2)
 
 
 0.1 (2021-08-25)

--- a/examples/pymt_heatpy_ex.py
+++ b/examples/pymt_heatpy_ex.py
@@ -42,9 +42,8 @@ grid_id = m.var_grid(var_name)
 print(" - grid id:", grid_id)
 print(" - grid type:", m.grid_type(grid_id))
 print(" - rank:", m.grid_ndim(grid_id))
-# print(" - size:", m.grid_node_count(grid_id))
-grid_size = int(np.prod(m.grid_shape(grid_id)))  # tmp fix
-print(" - size:", grid_size)  # tmp fix
+grid_size = m.grid_node_count(grid_id)
+print(" - size:", grid_size)
 print(" - shape:", m.grid_shape(grid_id))
 
 # Get the initial values of the variable.


### PR DESCRIPTION
This PR applies the fix from https://github.com/csdms/bmi-example-python/pull/20 to the pymt example.